### PR TITLE
Add architecture docs and database seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ dotnet run --project src/CleanTemplate.Api
 ```
 
 The API exposes sample endpoints to create orders, add items, and list stored events.
+
+## Documentation
+
+See [docs/README.md](docs/README.md) for an architecture overview, request flow diagram, and details about the automatic database seed that runs on startup.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# CleanTemplate Documentation
+
+## Architecture Overview
+
+This template follows a clean architecture with clearly separated layers:
+
+- **CleanTemplate.Domain** – core domain entities and events.
+- **CleanTemplate.Application** – application services that orchestrate domain behavior.
+- **CleanTemplate.Infrastructure** – EF Core implementation of the event store.
+- **CleanTemplate.Api** – ASP.NET Core API exposing order endpoints.
+
+## Flow Diagram
+
+```mermaid
+flowchart LR
+    Client -->|HTTP| Api
+    Api -->|uses| Application
+    Application -->|persists| EventStore
+    EventStore -->|stores| Database[(EventDbContext)]
+```
+
+## Database Seeding
+
+At startup the API seeds the in-memory event store with a sample order and one item. This is handled by `DataSeeder` in the API project.
+
+1. An order is created.
+2. A sample item (`"Sample"`, quantity `1`) is added.
+
+This provides immediate data for testing the event sourcing flow.

--- a/src/CleanTemplate.Api/DataSeeder.cs
+++ b/src/CleanTemplate.Api/DataSeeder.cs
@@ -1,0 +1,23 @@
+using CleanTemplate.Application.Services;
+using CleanTemplate.Infrastructure.EF;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CleanTemplate.Api;
+
+public static class DataSeeder
+{
+    public static async Task SeedAsync(IServiceProvider services)
+    {
+        using var scope = services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<EventDbContext>();
+        if (await context.Events.AnyAsync())
+        {
+            return;
+        }
+
+        var orders = scope.ServiceProvider.GetRequiredService<OrderService>();
+        var id = await orders.CreateAsync();
+        await orders.AddItemAsync(id, "Sample", 1);
+    }
+}

--- a/src/CleanTemplate.Api/Program.cs
+++ b/src/CleanTemplate.Api/Program.cs
@@ -3,6 +3,7 @@ using CleanTemplate.Application.Services;
 using CleanTemplate.Infrastructure.EF;
 using CleanTemplate.Infrastructure.EventStore;
 using Microsoft.EntityFrameworkCore;
+using CleanTemplate.Api;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,6 +16,8 @@ builder.Services.AddScoped<IEventStore, EfCoreEventStore>();
 builder.Services.AddScoped<OrderService>();
 
 var app = builder.Build();
+
+await DataSeeder.SeedAsync(app.Services);
 
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
## Summary
- add comprehensive documentation with flow diagram
- seed sample order data on API startup
- link documentation from root README

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b875f5c164832ea0af61d57fce91ce