### PR TITLE
Add product maker-checker workflow with event history

### DIFF
--- a/src/CleanTemplate.Api/Controllers/ProductsController.cs
+++ b/src/CleanTemplate.Api/Controllers/ProductsController.cs
@@ -1,0 +1,71 @@
+using CleanTemplate.Application.Services;
+using CleanTemplate.Domain.Events;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CleanTemplate.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ProductsController : ControllerBase
+{
+    private readonly ProductService _service;
+
+    public ProductsController(ProductService service) => _service = service;
+
+    [HttpPost]
+    public async Task<ActionResult<Guid>> Create([FromBody] CreateRequest request)
+    {
+        var id = await _service.CreateAsync(request.Name);
+        return Ok(id);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateRequest request)
+    {
+        await _service.UpdateAsync(id, request.Name);
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        await _service.DeleteAsync(id);
+        return NoContent();
+    }
+
+    [HttpPost("{id}/submit")]
+    public async Task<IActionResult> Submit(Guid id)
+    {
+        await _service.SubmitAsync(id);
+        return NoContent();
+    }
+
+    [HttpPost("{id}/approve")]
+    public async Task<IActionResult> Approve(Guid id)
+    {
+        await _service.ApproveAsync(id);
+        return NoContent();
+    }
+
+    [HttpPost("{id}/reject")]
+    public async Task<IActionResult> Reject(Guid id, [FromBody] CommentRequest request)
+    {
+        await _service.RejectAsync(id, request.Comment);
+        return NoContent();
+    }
+
+    [HttpPost("{id}/return")]
+    public async Task<IActionResult> Return(Guid id, [FromBody] CommentRequest request)
+    {
+        await _service.ReturnAsync(id, request.Comment);
+        return NoContent();
+    }
+
+    [HttpGet("{id}/events")]
+    public async Task<IEnumerable<IEvent>> GetEvents(Guid id) =>
+        await _service.GetEventsAsync(id);
+
+    public record CreateRequest(string Name);
+    public record UpdateRequest(string Name);
+    public record CommentRequest(string Comment);
+}

--- a/src/CleanTemplate.Api/Program.cs
+++ b/src/CleanTemplate.Api/Program.cs
@@ -13,6 +13,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddDbContext<EventDbContext>(opt => opt.UseInMemoryDatabase("events"));
 builder.Services.AddScoped<IEventStore, EfCoreEventStore>();
 builder.Services.AddScoped<OrderService>();
+builder.Services.AddScoped<ProductService>();
 
 var app = builder.Build();
 

--- a/src/CleanTemplate.Application/Services/ProductService.cs
+++ b/src/CleanTemplate.Application/Services/ProductService.cs
@@ -1,0 +1,74 @@
+using CleanTemplate.Application.Interfaces;
+using CleanTemplate.Domain.Entities;
+using CleanTemplate.Domain.Events;
+
+namespace CleanTemplate.Application.Services;
+
+public class ProductService
+{
+    private readonly IEventStore _eventStore;
+
+    public ProductService(IEventStore eventStore)
+    {
+        _eventStore = eventStore;
+    }
+
+    public async Task<Guid> CreateAsync(string name, CancellationToken ct = default)
+    {
+        var product = Product.Create(Guid.NewGuid(), name);
+        await _eventStore.SaveAsync(product.Id, product.Events, ct);
+        product.ClearEvents();
+        return product.Id;
+    }
+
+    private async Task<Product> LoadAsync(Guid id, CancellationToken ct)
+    {
+        var events = await _eventStore.GetAsync(id, ct);
+        return Product.Rehydrate(events);
+    }
+
+    public async Task UpdateAsync(Guid id, string name, CancellationToken ct = default)
+    {
+        var product = await LoadAsync(id, ct);
+        product.Update(name);
+        await _eventStore.SaveAsync(id, product.Events, ct);
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        var product = await LoadAsync(id, ct);
+        product.Delete();
+        await _eventStore.SaveAsync(id, product.Events, ct);
+    }
+
+    public async Task SubmitAsync(Guid id, CancellationToken ct = default)
+    {
+        var product = await LoadAsync(id, ct);
+        product.Submit();
+        await _eventStore.SaveAsync(id, product.Events, ct);
+    }
+
+    public async Task ApproveAsync(Guid id, CancellationToken ct = default)
+    {
+        var product = await LoadAsync(id, ct);
+        product.Approve();
+        await _eventStore.SaveAsync(id, product.Events, ct);
+    }
+
+    public async Task RejectAsync(Guid id, string comment, CancellationToken ct = default)
+    {
+        var product = await LoadAsync(id, ct);
+        product.Reject(comment);
+        await _eventStore.SaveAsync(id, product.Events, ct);
+    }
+
+    public async Task ReturnAsync(Guid id, string comment, CancellationToken ct = default)
+    {
+        var product = await LoadAsync(id, ct);
+        product.Return(comment);
+        await _eventStore.SaveAsync(id, product.Events, ct);
+    }
+
+    public async Task<IEnumerable<IEvent>> GetEventsAsync(Guid id, CancellationToken ct = default)
+        => await _eventStore.GetAsync(id, ct);
+}

--- a/src/CleanTemplate.Domain/Entities/Product.cs
+++ b/src/CleanTemplate.Domain/Entities/Product.cs
@@ -1,0 +1,124 @@
+using CleanTemplate.Domain.Events;
+
+namespace CleanTemplate.Domain.Entities;
+
+public enum ProductStatus
+{
+    Draft,
+    PendingApproval,
+    Approved,
+    Rejected,
+    Returned,
+    Deleted
+}
+
+public class Product : AggregateRoot
+{
+    public Guid Id { get; private set; }
+    public string Name { get; private set; } = string.Empty;
+    public ProductStatus Status { get; private set; } = ProductStatus.Draft;
+
+    private Product() { }
+
+    public static Product Create(Guid id, string name)
+    {
+        var product = new Product();
+        var evt = new ProductCreated(id, name, DateTime.UtcNow);
+        product.Apply(evt);
+        product.AddEvent(evt);
+        return product;
+    }
+
+    public static Product Rehydrate(IEnumerable<IEvent> events)
+    {
+        var product = new Product();
+        foreach (var e in events)
+        {
+            product.Apply(e);
+        }
+        return product;
+    }
+
+    public void Update(string name)
+    {
+        var evt = new ProductUpdated(Id, name, DateTime.UtcNow);
+        Apply(evt);
+        AddEvent(evt);
+    }
+
+    public void Delete()
+    {
+        var evt = new ProductDeleted(Id, DateTime.UtcNow);
+        Apply(evt);
+        AddEvent(evt);
+    }
+
+    public void Submit()
+    {
+        if (Status == ProductStatus.PendingApproval)
+            return;
+        var evt = new ProductSubmitted(Id, DateTime.UtcNow);
+        Apply(evt);
+        AddEvent(evt);
+    }
+
+    public void Approve()
+    {
+        if (Status != ProductStatus.PendingApproval) return;
+        var evt = new ProductApproved(Id, DateTime.UtcNow);
+        Apply(evt);
+        AddEvent(evt);
+    }
+
+    public void Reject(string comment)
+    {
+        if (string.IsNullOrWhiteSpace(comment))
+            throw new ArgumentException("Comment is required", nameof(comment));
+        if (Status != ProductStatus.PendingApproval)
+            throw new InvalidOperationException("Product not pending approval");
+        var evt = new ProductRejected(Id, comment, DateTime.UtcNow);
+        Apply(evt);
+        AddEvent(evt);
+    }
+
+    public void Return(string comment)
+    {
+        if (string.IsNullOrWhiteSpace(comment))
+            throw new ArgumentException("Comment is required", nameof(comment));
+        if (Status != ProductStatus.PendingApproval)
+            throw new InvalidOperationException("Product not pending approval");
+        var evt = new ProductReturned(Id, comment, DateTime.UtcNow);
+        Apply(evt);
+        AddEvent(evt);
+    }
+
+    private void Apply(IEvent @event)
+    {
+        switch (@event)
+        {
+            case ProductCreated created:
+                Id = created.ProductId;
+                Name = created.Name;
+                Status = ProductStatus.Draft;
+                break;
+            case ProductUpdated updated:
+                Name = updated.Name;
+                break;
+            case ProductDeleted:
+                Status = ProductStatus.Deleted;
+                break;
+            case ProductSubmitted:
+                Status = ProductStatus.PendingApproval;
+                break;
+            case ProductApproved:
+                Status = ProductStatus.Approved;
+                break;
+            case ProductRejected:
+                Status = ProductStatus.Rejected;
+                break;
+            case ProductReturned:
+                Status = ProductStatus.Returned;
+                break;
+        }
+    }
+}

--- a/src/CleanTemplate.Domain/Events/ProductApproved.cs
+++ b/src/CleanTemplate.Domain/Events/ProductApproved.cs
@@ -1,0 +1,6 @@
+namespace CleanTemplate.Domain.Events;
+
+public record ProductApproved(Guid ProductId, DateTime OccurredOn) : IEvent
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}

--- a/src/CleanTemplate.Domain/Events/ProductCreated.cs
+++ b/src/CleanTemplate.Domain/Events/ProductCreated.cs
@@ -1,0 +1,6 @@
+namespace CleanTemplate.Domain.Events;
+
+public record ProductCreated(Guid ProductId, string Name, DateTime OccurredOn) : IEvent
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}

--- a/src/CleanTemplate.Domain/Events/ProductDeleted.cs
+++ b/src/CleanTemplate.Domain/Events/ProductDeleted.cs
@@ -1,0 +1,6 @@
+namespace CleanTemplate.Domain.Events;
+
+public record ProductDeleted(Guid ProductId, DateTime OccurredOn) : IEvent
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}

--- a/src/CleanTemplate.Domain/Events/ProductRejected.cs
+++ b/src/CleanTemplate.Domain/Events/ProductRejected.cs
@@ -1,0 +1,6 @@
+namespace CleanTemplate.Domain.Events;
+
+public record ProductRejected(Guid ProductId, string Comment, DateTime OccurredOn) : IEvent
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}

--- a/src/CleanTemplate.Domain/Events/ProductReturned.cs
+++ b/src/CleanTemplate.Domain/Events/ProductReturned.cs
@@ -1,0 +1,6 @@
+namespace CleanTemplate.Domain.Events;
+
+public record ProductReturned(Guid ProductId, string Comment, DateTime OccurredOn) : IEvent
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}

--- a/src/CleanTemplate.Domain/Events/ProductSubmitted.cs
+++ b/src/CleanTemplate.Domain/Events/ProductSubmitted.cs
@@ -1,0 +1,6 @@
+namespace CleanTemplate.Domain.Events;
+
+public record ProductSubmitted(Guid ProductId, DateTime OccurredOn) : IEvent
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}

--- a/src/CleanTemplate.Domain/Events/ProductUpdated.cs
+++ b/src/CleanTemplate.Domain/Events/ProductUpdated.cs
@@ -1,0 +1,6 @@
+namespace CleanTemplate.Domain.Events;
+
+public record ProductUpdated(Guid ProductId, string Name, DateTime OccurredOn) : IEvent
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}

--- a/tests/CleanTemplate.Tests/ProductServiceTests.cs
+++ b/tests/CleanTemplate.Tests/ProductServiceTests.cs
@@ -1,0 +1,44 @@
+using CleanTemplate.Application.Interfaces;
+using CleanTemplate.Application.Services;
+using CleanTemplate.Domain.Events;
+using CleanTemplate.Infrastructure.EF;
+using CleanTemplate.Infrastructure.EventStore;
+using Microsoft.EntityFrameworkCore;
+
+public class ProductServiceTests
+{
+    private ProductService CreateService()
+    {
+        var options = new DbContextOptionsBuilder<EventDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var context = new EventDbContext(options);
+        IEventStore store = new EfCoreEventStore(context);
+        return new ProductService(store);
+    }
+
+    [Fact]
+    public async Task CreateSubmitReject_StoresEvents()
+    {
+        var service = CreateService();
+        var id = await service.CreateAsync("Test");
+        await service.SubmitAsync(id);
+        await service.RejectAsync(id, "not good");
+
+        var events = await service.GetEventsAsync(id);
+        Assert.Equal(3, events.Count());
+        Assert.Contains(events, e => e is ProductCreated);
+        Assert.Contains(events, e => e is ProductSubmitted);
+        Assert.Contains(events, e => e is ProductRejected);
+    }
+
+    [Fact]
+    public async Task RejectWithoutComment_Throws()
+    {
+        var service = CreateService();
+        var id = await service.CreateAsync("Test");
+        await service.SubmitAsync(id);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => service.RejectAsync(id, string.Empty));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce Product aggregate and events for maker-checker workflow
- add ProductService and API controller to manage product lifecycle
- include unit tests enforcing comment requirement and verifying history

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b87945c240832e92e66c4af5ba855c