### PR TITLE
Enable implicit usings and fix missing dependencies

### DIFF
--- a/src/CleanTemplate.Api/CleanTemplate.Api.csproj
+++ b/src/CleanTemplate.Api/CleanTemplate.Api.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CleanTemplate.Application\CleanTemplate.Application.csproj" />

--- a/src/CleanTemplate.Application/CleanTemplate.Application.csproj
+++ b/src/CleanTemplate.Application/CleanTemplate.Application.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\CleanTemplate.Domain\CleanTemplate.Domain.csproj" />

--- a/src/CleanTemplate.Domain/CleanTemplate.Domain.csproj
+++ b/src/CleanTemplate.Domain/CleanTemplate.Domain.csproj
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 </Project>

--- a/src/CleanTemplate.Infrastructure/CleanTemplate.Infrastructure.csproj
+++ b/src/CleanTemplate.Infrastructure/CleanTemplate.Infrastructure.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />

--- a/tests/CleanTemplate.Tests/CleanTemplate.Tests.csproj
+++ b/tests/CleanTemplate.Tests/CleanTemplate.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.5.0" />
@@ -10,5 +12,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\CleanTemplate.Application\CleanTemplate.Application.csproj" />
     <ProjectReference Include="..\..\src\CleanTemplate.Domain\CleanTemplate.Domain.csproj" />
+      <ProjectReference Include="..\..\src\CleanTemplate.Infrastructure\CleanTemplate.Infrastructure.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/CleanTemplate.Tests/OrderServiceTests.cs
+++ b/tests/CleanTemplate.Tests/OrderServiceTests.cs
@@ -1,3 +1,4 @@
+using Xunit;
 using CleanTemplate.Application.Interfaces;
 using CleanTemplate.Application.Services;
 using CleanTemplate.Domain.Events;

--- a/tests/CleanTemplate.Tests/ProductServiceTests.cs
+++ b/tests/CleanTemplate.Tests/ProductServiceTests.cs
@@ -1,3 +1,4 @@
+using Xunit;
 using CleanTemplate.Application.Interfaces;
 using CleanTemplate.Application.Services;
 using CleanTemplate.Domain.Events;


### PR DESCRIPTION
## Summary
- enable implicit usings across projects
- add Swashbuckle dependency for Swagger support
- update tests with infrastructure reference and xUnit usings

## Testing
- `dotnet run --project src/CleanTemplate.Api`
- `dotnet test tests/CleanTemplate.Tests/CleanTemplate.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b87cc4c260832ea5a0874d8d350d13