### PR TITLE
Add architecture tests and guidelines

### DIFF
--- a/docs/architecture-testing.md
+++ b/docs/architecture-testing.md
@@ -1,0 +1,28 @@
+# Architecture Testing Guidelines
+
+This repository uses [NetArchTest](https://github.com/BenMorris/NetArchTest) and xUnit to enforce clean architecture boundaries.
+
+## Location
+
+Architecture tests live in `tests/CleanTemplate.ArchitectureTests`.
+
+## Conventions
+
+- Target .NET 8.0 and enable nullable reference types.
+- Reference the `CleanTemplate.Domain`, `CleanTemplate.Application`, and `CleanTemplate.Infrastructure` projects to examine dependencies.
+- Verify that:
+  - Domain does not depend on Application or Infrastructure.
+  - Application does not depend on Infrastructure.
+- Use `NetArchTest.Rules` to express dependency rules.
+
+## Running tests
+
+Run all tests, including architecture checks, from the repository root:
+
+```bash
+dotnet test
+```
+
+## Adding new features
+
+When new layers or projects are added, extend the architecture tests to validate their dependency rules and keep this document updated with any new guidelines.

--- a/tests/CleanTemplate.ArchitectureTests/CleanTemplate.ArchitectureTests.csproj
+++ b/tests/CleanTemplate.ArchitectureTests/CleanTemplate.ArchitectureTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CleanTemplate.Domain\CleanTemplate.Domain.csproj" />
+    <ProjectReference Include="..\..\src\CleanTemplate.Application\CleanTemplate.Application.csproj" />
+    <ProjectReference Include="..\..\src\CleanTemplate.Infrastructure\CleanTemplate.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/CleanTemplate.ArchitectureTests/LayeringTests.cs
+++ b/tests/CleanTemplate.ArchitectureTests/LayeringTests.cs
@@ -1,0 +1,31 @@
+using NetArchTest.Rules;
+using CleanTemplate.Domain.Entities;
+using CleanTemplate.Application.Services;
+using Xunit;
+
+namespace CleanTemplate.ArchitectureTests;
+
+public class LayeringTests
+{
+    [Fact]
+    public void Domain_Should_Not_Depend_On_Other_Layers()
+    {
+        var result = Types.InAssembly(typeof(Order).Assembly)
+            .ShouldNot()
+            .HaveDependencyOnAny("CleanTemplate.Application", "CleanTemplate.Infrastructure")
+            .GetResult();
+
+        Assert.True(result.IsSuccessful, "Domain layer has forbidden dependencies.");
+    }
+
+    [Fact]
+    public void Application_Should_Not_Depend_On_Infrastructure()
+    {
+        var result = Types.InAssembly(typeof(OrderService).Assembly)
+            .ShouldNot()
+            .HaveDependencyOn("CleanTemplate.Infrastructure")
+            .GetResult();
+
+        Assert.True(result.IsSuccessful, "Application layer depends on Infrastructure.");
+    }
+}


### PR DESCRIPTION
## Summary
- add architecture test project to enforce layering boundaries
- document architecture testing guidelines for future contributors

## Testing
- `dotnet test tests/CleanTemplate.Tests/CleanTemplate.Tests.csproj`
- `dotnet test tests/CleanTemplate.ArchitectureTests/CleanTemplate.ArchitectureTests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b889c758e4832e80e9cc0f62519b55