### PR TITLE
Add snapshot support to event store

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CleanTemplate
 
-This repository provides a minimal .NET 8 microservice template following a clean architecture approach with simple event sourcing backed by Entity Framework Core.
+This repository provides a minimal .NET 8 microservice template following a clean architecture approach with simple event sourcing backed by Entity Framework Core, including optional snapshotting to speed up aggregate rehydration.
 
 ## Projects
 

--- a/src/CleanTemplate.Application/Interfaces/IEventStore.cs
+++ b/src/CleanTemplate.Application/Interfaces/IEventStore.cs
@@ -6,4 +6,6 @@ public interface IEventStore
 {
     Task SaveAsync(Guid aggregateId, IEnumerable<IEvent> events, CancellationToken cancellationToken = default);
     Task<IEnumerable<IEvent>> GetAsync(Guid aggregateId, CancellationToken cancellationToken = default);
+    Task SaveSnapshotAsync<T>(Guid aggregateId, T snapshot, CancellationToken cancellationToken = default);
+    Task<(T? Snapshot, IEnumerable<IEvent> Events)> GetWithSnapshotAsync<T>(Guid aggregateId, CancellationToken cancellationToken = default);
 }

--- a/src/CleanTemplate.Infrastructure/EF/EventDbContext.cs
+++ b/src/CleanTemplate.Infrastructure/EF/EventDbContext.cs
@@ -8,4 +8,5 @@ public class EventDbContext : DbContext
     public EventDbContext(DbContextOptions<EventDbContext> options) : base(options) { }
 
     public DbSet<EventEntity> Events => Set<EventEntity>();
+    public DbSet<SnapshotEntity> Snapshots => Set<SnapshotEntity>();
 }

--- a/src/CleanTemplate.Infrastructure/EventStore/EfCoreEventStore.cs
+++ b/src/CleanTemplate.Infrastructure/EventStore/EfCoreEventStore.cs
@@ -50,4 +50,55 @@ public class EfCoreEventStore : IEventStore
 
         return events;
     }
+
+    public async Task SaveSnapshotAsync<T>(Guid aggregateId, T snapshot, CancellationToken cancellationToken = default)
+    {
+        var entity = new SnapshotEntity
+        {
+            Id = Guid.NewGuid(),
+            AggregateId = aggregateId,
+            Type = snapshot!.GetType().AssemblyQualifiedName!,
+            Data = JsonSerializer.Serialize(snapshot, snapshot.GetType()),
+            CreatedOn = DateTime.UtcNow
+        };
+        _context.Snapshots.Add(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<(T? Snapshot, IEnumerable<IEvent> Events)> GetWithSnapshotAsync<T>(Guid aggregateId, CancellationToken cancellationToken = default)
+    {
+        var snapshotEntity = await _context.Snapshots
+            .Where(s => s.AggregateId == aggregateId)
+            .OrderByDescending(s => s.CreatedOn)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        T? snapshot = default;
+        DateTime? from = null;
+        if (snapshotEntity != null)
+        {
+            var type = Type.GetType(snapshotEntity.Type)!;
+            snapshot = (T)JsonSerializer.Deserialize(snapshotEntity.Data, type)!;
+            from = snapshotEntity.CreatedOn;
+        }
+
+        var query = _context.Events.Where(e => e.AggregateId == aggregateId);
+        if (from.HasValue)
+        {
+            query = query.Where(e => e.OccurredOn > from.Value);
+        }
+
+        var entities = await query
+            .OrderBy(e => e.OccurredOn)
+            .ToListAsync(cancellationToken);
+
+        var events = new List<IEvent>();
+        foreach (var entity in entities)
+        {
+            var type = Type.GetType(entity.Type)!;
+            var @event = (IEvent)JsonSerializer.Deserialize(entity.Data, type)!;
+            events.Add(@event);
+        }
+
+        return (snapshot, events);
+    }
 }

--- a/src/CleanTemplate.Infrastructure/EventStore/SnapshotEntity.cs
+++ b/src/CleanTemplate.Infrastructure/EventStore/SnapshotEntity.cs
@@ -1,0 +1,10 @@
+namespace CleanTemplate.Infrastructure.EventStore;
+
+public class SnapshotEntity
+{
+    public Guid Id { get; set; }
+    public Guid AggregateId { get; set; }
+    public string Type { get; set; } = default!;
+    public string Data { get; set; } = default!;
+    public DateTime CreatedOn { get; set; }
+}

--- a/tests/CleanTemplate.Tests/EventStoreSnapshotTests.cs
+++ b/tests/CleanTemplate.Tests/EventStoreSnapshotTests.cs
@@ -1,0 +1,37 @@
+using Xunit;
+using CleanTemplate.Application.Interfaces;
+using CleanTemplate.Domain.Events;
+using CleanTemplate.Infrastructure.EF;
+using CleanTemplate.Infrastructure.EventStore;
+using Microsoft.EntityFrameworkCore;
+
+public class EventStoreSnapshotTests
+{
+    private EfCoreEventStore CreateStore()
+    {
+        var options = new DbContextOptionsBuilder<EventDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var context = new EventDbContext(options);
+        return new EfCoreEventStore(context);
+    }
+
+    private record ProductSnapshot(string Name);
+
+    [Fact]
+    public async Task SaveAndLoadSnapshot_ReturnsRemainingEvents()
+    {
+        var store = CreateStore();
+        var id = Guid.NewGuid();
+        await store.SaveAsync(id, new IEvent[] { new ProductCreated(id, "Test", DateTime.UtcNow) });
+        await store.SaveSnapshotAsync(id, new ProductSnapshot("Test"));
+        await store.SaveAsync(id, new IEvent[] { new ProductSubmitted(id, DateTime.UtcNow) });
+
+        var (snapshot, events) = await store.GetWithSnapshotAsync<ProductSnapshot>(id);
+
+        Assert.NotNull(snapshot);
+        Assert.Equal("Test", snapshot!.Name);
+        Assert.Single(events);
+        Assert.Contains(events, e => e is ProductSubmitted);
+    }
+}


### PR DESCRIPTION
## Summary
- add optional snapshotting to the event store for faster aggregate rehydration
- include snapshot persistence via EF Core and retrieval alongside remaining events
- document snapshot capability and add unit tests

## Testing
- `dotnet test tests/CleanTemplate.Tests/CleanTemplate.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b88e33ba4c832eb2088ca1ab377e42