### PR TITLE
Store aggregate metadata in snapshots

### DIFF
--- a/src/CleanTemplate.Application/Interfaces/IEventStore.cs
+++ b/src/CleanTemplate.Application/Interfaces/IEventStore.cs
@@ -6,6 +6,6 @@ public interface IEventStore
 {
     Task SaveAsync(Guid aggregateId, IEnumerable<IEvent> events, CancellationToken cancellationToken = default);
     Task<IEnumerable<IEvent>> GetAsync(Guid aggregateId, CancellationToken cancellationToken = default);
-    Task SaveSnapshotAsync<T>(Guid aggregateId, T snapshot, CancellationToken cancellationToken = default);
-    Task<(T? Snapshot, IEnumerable<IEvent> Events)> GetWithSnapshotAsync<T>(Guid aggregateId, CancellationToken cancellationToken = default);
+    Task SaveSnapshotAsync<T>(Guid aggregateId, T state, CancellationToken cancellationToken = default);
+    Task<(Snapshot<T>? Snapshot, IEnumerable<IEvent> Events)> GetWithSnapshotAsync<T>(Guid aggregateId, CancellationToken cancellationToken = default);
 }

--- a/src/CleanTemplate.Application/Interfaces/Snapshot.cs
+++ b/src/CleanTemplate.Application/Interfaces/Snapshot.cs
@@ -1,0 +1,7 @@
+namespace CleanTemplate.Application.Interfaces;
+
+/// <summary>
+/// Represents a snapshot of an aggregate with its type, identifier and state.
+/// </summary>
+/// <typeparam name="TState">Type of the aggregate state stored in the snapshot.</typeparam>
+public record Snapshot<TState>(Guid AggregateId, string AggregateType, TState State);

--- a/src/CleanTemplate.Infrastructure/EventStore/SnapshotEntity.cs
+++ b/src/CleanTemplate.Infrastructure/EventStore/SnapshotEntity.cs
@@ -4,7 +4,7 @@ public class SnapshotEntity
 {
     public Guid Id { get; set; }
     public Guid AggregateId { get; set; }
-    public string Type { get; set; } = default!;
-    public string Data { get; set; } = default!;
+    public string AggregateType { get; set; } = default!;
+    public string State { get; set; } = default!;
     public DateTime CreatedOn { get; set; }
 }

--- a/tests/CleanTemplate.Tests/EventStoreSnapshotTests.cs
+++ b/tests/CleanTemplate.Tests/EventStoreSnapshotTests.cs
@@ -1,6 +1,7 @@
 using Xunit;
 using CleanTemplate.Application.Interfaces;
 using CleanTemplate.Domain.Events;
+using CleanTemplate.Domain.Entities;
 using CleanTemplate.Infrastructure.EF;
 using CleanTemplate.Infrastructure.EventStore;
 using Microsoft.EntityFrameworkCore;
@@ -16,21 +17,23 @@ public class EventStoreSnapshotTests
         return new EfCoreEventStore(context);
     }
 
-    private record ProductSnapshot(string Name);
-
     [Fact]
     public async Task SaveAndLoadSnapshot_ReturnsRemainingEvents()
     {
         var store = CreateStore();
         var id = Guid.NewGuid();
-        await store.SaveAsync(id, new IEvent[] { new ProductCreated(id, "Test", DateTime.UtcNow) });
-        await store.SaveSnapshotAsync(id, new ProductSnapshot("Test"));
+        var product = Product.Create(id, "Test");
+        await store.SaveAsync(id, product.Events);
+        product.ClearEvents();
+        await store.SaveSnapshotAsync(id, product);
         await store.SaveAsync(id, new IEvent[] { new ProductSubmitted(id, DateTime.UtcNow) });
 
-        var (snapshot, events) = await store.GetWithSnapshotAsync<ProductSnapshot>(id);
+        var (snapshot, events) = await store.GetWithSnapshotAsync<Product>(id);
 
         Assert.NotNull(snapshot);
-        Assert.Equal("Test", snapshot!.Name);
+        Assert.Equal(typeof(Product).AssemblyQualifiedName, snapshot!.AggregateType);
+        Assert.Equal(id, snapshot.AggregateId);
+        Assert.Equal("Test", snapshot.State.Name);
         Assert.Single(events);
         Assert.Contains(events, e => e is ProductSubmitted);
     }


### PR DESCRIPTION
## Summary
- Introduce `Snapshot<TState>` record capturing aggregate id, type, and state
- Persist aggregate type and serialized state in EF Core snapshot entity
- Expose snapshot metadata through event store and update snapshot tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*
- `bash /tmp/dotnet-install.sh --version 8.0.100` *(incomplete; environment interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bab68f0bdc832eaf0485ccb5828a36